### PR TITLE
Do not throw compiler error for WSGL warnings?

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -101,10 +101,11 @@ export default class WGPURenderer {
     this._renderPipelines.update(this._device, material, binding.layout);
     const module = this._renderPipelines.get(material).module;
     const log = await module.getLog();
-    if (log.messages.length > 0) {
+    const errors = log.messages.filter(m => m.type == "error");
+    if (errors.length > 0) {
       this._bindings.remove(material);
       this._renderPipelines.remove(material);
-      throw new CompileError(log.messages.slice(), 'Compile error');
+      throw new CompileError(errors.slice(), 'Compile error');
     }
   }
 


### PR DESCRIPTION
While working on https://github.com/takahirox/online-wgsl-editor/pull/16 I realized that editor was refusing to run the code even though there only warnings, not errors.

I'm not sure if this was the desired behavior or not. This PR allows a shader to run even if it has some warnings. The other type of log message that may be returned is `info` (see https://www.w3.org/TR/webgpu/#enumdef-gpucompilationmessagetype) so it seems like a good idea to allow it to run if such messages are present.

Perhaps warnings can still be communicated in the code editor while allowing the code to run? This would require a bit of a refactor to communicate I think. Feel free to close this PR if you are aware of this issue/have another idea to improve it!