### PR TITLE
Update to follow the latest WebGPU spec

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -211,7 +211,7 @@ class WGPUShaderModule {
   }
 
   getLog(device) {
-    return this.module.compilationInfo();
+    return this.module.getCompilationInfo();
   }
 }
 


### PR DESCRIPTION
Rename from GPUShaderModule.compilationInfo() to GPUShaderModule.getCompilationInfo()